### PR TITLE
Refactor stock warning logic into repository

### DIFF
--- a/app/Repositories/Contracts/ProductRepositoryInterface.php
+++ b/app/Repositories/Contracts/ProductRepositoryInterface.php
@@ -16,6 +16,8 @@ interface ProductRepositoryInterface
     public function hide($id);
     public function getAllStock();
     public function getStockById($id);
+    public function searchStockWarning($query = '', $date = null, $page = 1, $perPage = 10);
+    public function stockWarning($page = 1, $perPage = 10);
     public function search($params);
     public function getProductsByCategoryId($categoryId);
     public function getProductsByCategory($categoryId);

--- a/app/Repositories/Eloquent/ProductRepository.php
+++ b/app/Repositories/Eloquent/ProductRepository.php
@@ -394,6 +394,169 @@ class ProductRepository implements ProductRepositoryInterface
         ];
     }
 
+    public function searchStockWarning($query = '', $date = null, $page = 1, $perPage = 10)
+    {
+        if ($date) {
+            $start = Carbon::parse($date)->startOfDay();
+            $end = Carbon::parse($date)->endOfDay();
+        } else {
+            $end = now()->startOfDay()->setTime(23, 59, 59);
+            $start = $end->copy()->subDay()->setTime(0, 0, 0);
+        }
+
+        $productsQuery = $this->model->with(['productSizes.recipes.flower']);
+        if ($query) {
+            $productsQuery->where('name', 'like', '%' . $query . '%');
+        }
+        $products = $productsQuery->get();
+
+        $result = [
+            'available' => [],
+            'low' => [],
+            'out' => []
+        ];
+
+        foreach ($products as $product) {
+            $groupedSizes = [
+                'available' => [],
+                'low' => [],
+                'out' => []
+            ];
+
+            foreach ($product->productSizes as $size) {
+                $minStock = PHP_INT_MAX;
+                $limitingFlower = null;
+                foreach ($size->recipes as $recipe) {
+                    $flowerId = $recipe->flower_id;
+                    $needed = $recipe->quantity;
+                    $stock = ImportReceiptDetail::where('flower_id', $flowerId)
+                        ->whereBetween('import_date', [$start, $end])
+                        ->select(DB::raw('SUM(quantity - used_quantity) as remaining'))
+                        ->value('remaining') ?? 0;
+                    $possible = $needed > 0 ? floor($stock / $needed) : 0;
+                    if ($possible < $minStock) {
+                        $minStock = $possible;
+                        $limitingFlower = [
+                            'id' => $flowerId,
+                            'name' => $recipe->flower->name,
+                            'available' => $stock,
+                            'needed' => $needed
+                        ];
+                    }
+                }
+                $sizeItem = [
+                    'size_id' => $size->id,
+                    'size' => $size->size,
+                    'max_quantity' => $minStock,
+                    'limiting_flower' => $limitingFlower
+                ];
+
+                if ($minStock === 0.0) {
+                    $groupedSizes['out'][] = $sizeItem;
+                } elseif ($minStock <= 10) {
+                    $groupedSizes['low'][] = $sizeItem;
+                } else {
+                    $groupedSizes['available'][] = $sizeItem;
+                }
+            }
+
+            foreach (['available', 'low', 'out'] as $group) {
+                if (!empty($groupedSizes[$group])) {
+                    $result[$group][] = [
+                        'product_id' => $product->id,
+                        'product_image' => $product->image_url,
+                        'product_name' => $product->name,
+                        'product_sizes' => $groupedSizes[$group]
+                    ];
+                }
+            }
+        }
+
+        foreach ($result as &$group) {
+            usort($group, function ($a, $b) {
+                return $a['product_id'] <=> $b['product_id'];
+            });
+        }
+
+        $paginateGroup = function ($group) use ($page, $perPage) {
+            $total = count($group);
+            $lastPage = ceil($total / $perPage);
+            $paged = array_slice($group, ($page - 1) * $perPage, $perPage);
+            return [
+                'data' => $paged,
+                'current_page' => $page,
+                'per_page' => $perPage,
+                'total' => $total,
+                'last_page' => $lastPage
+            ];
+        };
+
+        return [
+            'available' => $paginateGroup($result['available']),
+            'low' => $paginateGroup($result['low']),
+            'out' => $paginateGroup($result['out']),
+        ];
+    }
+
+    public function stockWarning($page = 1, $perPage = 10)
+    {
+        $today = now()->format('Y-m-d');
+        $products = $this->model->with(['productSizes.recipes.flower'])->paginate($perPage, ['*'], 'page', $page);
+        $result = [];
+
+        foreach ($products as $product) {
+            foreach ($product->productSizes as $size) {
+                $minStock = PHP_INT_MAX;
+                $limitingFlower = null;
+                foreach ($size->recipes as $recipe) {
+                    $flowerId = $recipe->flower_id;
+                    $needed = $recipe->quantity;
+                    $stock = ImportReceiptDetail::where('flower_id', $flowerId)
+                        ->whereDate('import_date', $today)
+                        ->select(DB::raw('SUM(quantity - used_quantity) as remaining'))
+                        ->value('remaining') ?? 0;
+                    $possible = $needed > 0 ? floor($stock / $needed) : 0;
+                    if ($possible < $minStock) {
+                        $minStock = $possible;
+                        $limitingFlower = [
+                            'id' => $flowerId,
+                            'name' => $recipe->flower->name,
+                            'available' => $stock,
+                            'needed' => $needed
+                        ];
+                    }
+                }
+                $result[] = [
+                    'product_id' => $product->id,
+                    'product_image' => $product->image_url,
+                    'product_name' => $product->name,
+                    'size_id' => $size->id,
+                    'size' => $size->size,
+                    'max_quantity' => $minStock,
+                    'limiting_flower' => $limitingFlower,
+                    'warning' => $minStock <= 3
+                ];
+            }
+        }
+
+        usort($result, function ($a, $b) {
+            return $a['max_quantity'] <=> $b['max_quantity'];
+        });
+
+        $currentPage = $products->currentPage();
+        $perPage = $products->perPage();
+        $total = $products->total();
+        $lastPage = $products->lastPage();
+
+        return [
+            'data' => $result,
+            'current_page' => $currentPage,
+            'per_page' => $perPage,
+            'total' => $total,
+            'last_page' => $lastPage,
+        ];
+    }
+
     public function checkStock(Request $request)
     {
         $request->validate([


### PR DESCRIPTION
## Summary
- Move stock warning computations into `ProductRepository` with dedicated methods
- Expose repository methods and simplify controller to delegate stock warning queries

## Testing
- `composer install` *(fails: lcobucci/clock 2.3.0 requires php ~8.1.0 || ~8.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_6894f400b8ac832c8bd13fb069b5d5d0